### PR TITLE
Event coloring - different approach

### DIFF
--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -213,7 +213,6 @@ public class DateTime.Indicator : Wingpanel.Indicator {
             /* Color menuitem per calendar source of event */
             var css_class = Util.get_style_calendar_color (e.cal);
             menuitem.get_style_context ().add_class (css_class);
-            menuitem_icon.get_style_context ().add_class (css_class);
 
             e.cal.notify["color"].connect (() => {
                 Util.get_style_calendar_color (e.cal); /* Redefines same class */

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -211,8 +211,6 @@ public class DateTime.Indicator : Wingpanel.Indicator {
             event_grid.add (menuitem);
 
             /* Color menuitem per calendar source of event */
-            /* PROBLEM - all events in model are associated with the same calendar at the moment,
-             * therefore same color. Need to investigate why model is incorrect */
             var css_class = Util.get_style_calendar_color (e.cal);
             menuitem.get_style_context ().add_class (css_class);
             menuitem_icon.get_style_context ().add_class (css_class);

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -185,7 +185,6 @@ public class DateTime.Indicator : Wingpanel.Indicator {
         foreach (var e in events) {
             count += 1;
             var menuitem_icon = new Gtk.Image.from_icon_name (e.get_icon (), Gtk.IconSize.MENU);
-            menuitem_icon.get_style_context ().add_class ("event-icon-%i".printf(count));
             menuitem_icon.valign = Gtk.Align.CENTER;
 
             var menuitem_label = new Gtk.Label (e.get_label ());
@@ -213,10 +212,12 @@ public class DateTime.Indicator : Wingpanel.Indicator {
             event_grid.add (menuitem);
 
             /* Color events per calendar */
-            Util.style_calendar_color (menuitem, menuitem_icon, e.cal.dup_color (), count);
+            var css_class = Util.get_style_calendar_color (e.cal);
+            menuitem.get_style_context ().add_class (css_class);
+            menuitem_icon.get_style_context ().add_class (css_class);
 
             e.cal.notify["color"].connect (() => {
-                Util.style_calendar_color (menuitem, menuitem_icon, e.cal.dup_color (), count);
+                Util.get_style_calendar_color (e.cal); /* Redefines same class */
             });
         }
 

--- a/src/Widgets/calendar/CalendarModel.vala
+++ b/src/Widgets/calendar/CalendarModel.vala
@@ -304,15 +304,13 @@ namespace DateTime.Widgets {
             var events = new Gee.TreeMap<string,Event> ();
             registry.list_sources (E.SOURCE_EXTENSION_CALENDAR).foreach ((source) => {
                 E.SourceCalendar cal = (E.SourceCalendar)source.get_extension (E.SOURCE_EXTENSION_CALENDAR);
-                foreach (var entry in source_events.get_values ()) {
-                    foreach (var comp in entry.values) {
-                        unowned iCal.Component ical = comp.get_icalcomponent ();
-                        foreach (var dt_range in Util.event_date_ranges (ical, data_range)) {
-                            if (dt_range.contains (date)) {
-                                if (!events.has_key (ical.get_uid ())) {
-                                    if (cal.selected == true && source.enabled == true) {
-                                        events.set (ical.get_uid (), new Event (date, dt_range, ical, source));
-                                    }
+                foreach (var comp in source_events.get (source).values.read_only_view) {
+                    unowned iCal.Component ical = comp.get_icalcomponent ();
+                    foreach (var dt_range in Util.event_date_ranges (ical, data_range)) {
+                        if (dt_range.contains (date)) {
+                            if (!events.has_key (ical.get_uid ())) {
+                                if (cal.selected == true && source.enabled == true) {
+                                    events.set (ical.get_uid (), new Event (date, dt_range, ical, source));
                                 }
                             }
                         }

--- a/src/Widgets/calendar/Util.vala
+++ b/src/Widgets/calendar/Util.vala
@@ -160,31 +160,31 @@ namespace Util {
         return datetime.add_full (0, 0, 0, -datetime.get_hour (), -datetime.get_minute (), -datetime.get_second ());
     }
 
-    public void style_calendar_color (Gtk.Widget widget, Gtk.Widget widget2, string color, int count) {
+    public string get_style_calendar_color (E.SourceCalendar cal) {
+        var uid = cal.source.uid;
+        var color = cal.dup_color ();
+        string css_class = "event-color-%s".printf (uid);
+
         string style = """
-                        .event-color-%i {
+                        .%s {
                             background-color: alpha(%s, 0.15);
                             color: shade(%s, 0.65);
                             border-radius: 4px;
                         }
-                        .event-color-%i image {
+                        .%s image {
                             color: shade(%s, 0.65);
                         }
-                       """.printf(count, color, color, count, color);
+                       """.printf(css_class, color, color, css_class, color);
 
-        var style_context = widget.get_style_context ();
-        var style_context2 = widget2.get_style_context ();
         var style_provider = new Gtk.CssProvider ();
-
-        style_context.add_class ("event-color-%i".printf(count));
-
         try {
             style_provider.load_from_data (style, style.length);
-            style_context.add_provider (style_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
-            style_context2.add_provider (style_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+            Gtk.StyleContext.add_provider_for_screen (Gdk.Screen.get_default (), style_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
         } catch (Error e) {
             warning ("Could not create CSS Provider: %s\nStylesheet:\n%s", e.message, style);
         }
+
+        return css_class;
     }
 
     /**


### PR DESCRIPTION
Create one styleclass per calendar rather than per event.

Still gets the same color per event but this is due to a deeper problem with event creation not with the coloring logic.
